### PR TITLE
Uploading Arc videos to be included in content

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/Content/videos/arc-enabled-sql/Arc Sql Benefits.mp4
+++ b/Content/videos/arc-enabled-sql/Arc Sql Benefits.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdc31d11f969a3ae73bf8425656e64d2b12f43db6ae809a27bb0f8f363129edf
+size 411648287

--- a/Content/videos/arc-enabled-sql/Arc Sql Install Full.mp4
+++ b/Content/videos/arc-enabled-sql/Arc Sql Install Full.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9d8a41d6889be1a243b0beb069e7116458883cae4421e6e42d639bcb2fbe1ee
+size 461571265


### PR DESCRIPTION
Videos from original Arc sway have been included in directory \Content\videos\arc-enabled-sql\
Also added LFS extension to allow for large file uploads so that we can use videos

TODO: We may need to create a "contrib" document that mentions needing git lfs if they want to add videos.